### PR TITLE
Use a htpasswd file to manage users login

### DIFF
--- a/pritunl/constants.py
+++ b/pritunl/constants.py
@@ -1,4 +1,5 @@
 import string
+import os
 
 APP_NAME = 'pritunl'
 APP_NAME_FORMATED = 'Pritunl'
@@ -17,12 +18,12 @@ NAME_SAFE_CHARS = ['-', '_', '@', '.']
 KEY_LINK_TIMEOUT = 86400
 DEFAULT_PRIMARY_INTERFACE = 'eth0'
 DEFAULT_SESSION_TIMEOUT = 86400
-DEFAULT_PASSWORD = 'admin'
-PASSWORD_SALT = '2511cebca93d028393735637bbc8029207731fcf'
-DEFAULT_CONF_PATH = '/etc/pritunl.conf'
-DEFAULT_DB_PATH = '/var/lib/pritunl/pritunl.db'
-DEFAULT_WWW_PATH = '/usr/share/pritunl/www'
+DEFAULT_CONF_DIR_PATH = '/etc/pritunl'
 DEFAULT_DATA_PATH = '/var/lib/pritunl'
+DEFAULT_CONF_PATH = os.path.join(DEFAULT_CONF_DIR_PATH, 'pritunl.conf')
+DEFAULT_DB_PATH = os.path.join(DEFAULT_DATA_PATH, 'pritunl.db')
+DEFAULT_WWW_PATH = '/usr/share/pritunl/www'
+DEFAULT_PASSWORD_PATH = os.path.join(DEFAULT_CONF_DIR_PATH, 'user.db')
 DEFAULT_KEY_BITS = 4096
 DEFAULT_DH_PARAM_BITS = 1536
 DEFAULT_OTP_SECRET_LEN = 16

--- a/pritunl/handlers/auth.py
+++ b/pritunl/handlers/auth.py
@@ -10,7 +10,7 @@ def auth_post():
     username = flask.request.json['username'][:512]
     password = flask.request.json['password'][:512]
 
-    if username != AUTH_USER_NAME or not app_server.check_password(password):
+    if not app_server.check_password(username, password):
         time.sleep(RATE_LIMIT_SLEEP)
         return utils.jsonify({
             'error': AUTH_INVALID,

--- a/pritunl/handlers/password.py
+++ b/pritunl/handlers/password.py
@@ -6,8 +6,10 @@ import flask
 @app_server.app.route('/password', methods=['PUT'])
 @app_server.auth
 def password_put():
-    password = flask.request.json['password'][:512]
-    app_server.set_password(password)
+    username = flask.request.json['username'] or "admin" if 'username' in flask.request.json else "admin"
+    password = flask.request.json['password']
+    app_server.set_password(username, password)
     return utils.jsonify({
+        'username': username,
         'password': password,
     })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=0.6
 cherrypy>=3.2.0
+passlib>=1.6

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if not os.path.exists('build'):
     os.mkdir('build')
 
 data_files = [
-    ('/etc', ['data/etc/pritunl.conf']),
+    ('/etc/pritunl', ['data/etc/pritunl.conf']),
     ('/var/log', ['data/var/pritunl.log']),
     ('/usr/share/pritunl/www', ['www/key_index.html']),
     ('/usr/share/pritunl/www', ['www/vendor/dist/favicon.ico']),


### PR DESCRIPTION
This permit many good things:
- be able to set more users thant only "admin"
- be able to use external tools to manipulate this file
- don't change configuration file on run (it doesn't fit with configuration management tools templating)
