### PR TITLE
Dockerfile to build Docker image and run as container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM gliderlabs/alpine:3.1
+
+RUN apk-install python py-pip openssl ca-certificates procps openvpn
+
+WORKDIR /pritunl
+
+COPY . /pritunl
+
+RUN apk-install --virtual build python-dev build-base wget \
+  && pip install -r requirements.txt \
+  && python setup.py install \
+  && apk del --purge -r build
+
+CMD pritunl start


### PR DESCRIPTION
This adds a `Dockerfile` which builds a small-ish 85 MB image that runs Pritunl as a Docker container.

To build:

```shell
$ docker build -t pritunl .
```

An example of running:

```shell
$ docker run --name mongo -d mongo
$ docker run --name pritunl -p 9700:9700 -p 14104:14104/udp --privileged -d pritunl
```

Then access the interface on your Docker host at port `9700` and create a server that listens on port `14104` UDP.

Privileged mode is currently available because the server tries to set some `sysctl` settings. If we could instead check to see if sysctl values needed to be changed before trying to set them, we could probably remove `--privileged` in the future.