### PR TITLE
Enable none smtp ssl when missing stmp creds

### DIFF
--- a/pritunl/utils/mail.py
+++ b/pritunl/utils/mail.py
@@ -13,9 +13,8 @@ def send_email(to_addr, subject, text_body, html_body):
     email_username = settings.app.email_username
     email_password = settings.app.email_password
 
-    if not email_server or not email_from or not \
-            email_username or not email_password:
-        raise EmailNotConfiguredError('Email not configured')
+    if not email_server or not email_from:
+        raise EmailNotConfiguredError('STMP Server or STMP From Address not configured')
 
     msg = email.mime.multipart.MIMEMultipart('alternative')
     msg['Subject'] = subject
@@ -26,10 +25,18 @@ def send_email(to_addr, subject, text_body, html_body):
     msg.attach(email.mime.text.MIMEText(html_body, 'html'))
 
     try:
-        smtp_conn = smtplib.SMTP_SSL(email_server)
-        smtp_conn.login(email_username, email_password)
+        if not email_username or not email_password:
+            smtp_conn = smtplib.SMTP(email_server)
+        else:
+            if not email_username or not email_password:
+                raise EmailNotConfiguredError('STMP Username or STMP Password not configured')
+            else:
+                smtp_conn = smtplib.SMTP_SSL(email_server)
+                smtp_conn.login(email_username, email_password)
+
         smtp_conn.sendmail(email_from, to_addr, msg.as_string())
         smtp_conn.quit()
+
     except smtplib.SMTPAuthenticationError:
         raise EmailAuthInvalid('Email auth is invalid')
     except smtplib.SMTPSenderRefused:


### PR DESCRIPTION
To enable none stmp when no username and password configured for the stmp server.