### PR TITLE
Using psutil to get process info

### DIFF
--- a/pritunl/utils/misc.py
+++ b/pritunl/utils/misc.py
@@ -22,6 +22,7 @@ import Queue
 import urllib2
 import json
 import math
+import psutil
 
 _null = open(os.devnull, 'w')
 
@@ -404,18 +405,8 @@ def ping(address, timeout=1):
     return runtime
 
 def get_process_cpu_mem():
-    output = subprocess.check_output([
-        'ps', '-p', str(os.getpid()), '-o', '%cpu,%mem'])
-
-    output = output.split('\n')
-    if len(output) < 2:
-        raise ValueError('Invalid output')
-
-    output = output[1].strip().split()
-    if len(output) != 2:
-        raise ValueError('Invalid output')
-
-    return float(output[0]), float(output[1])
+    proc = psutil.Process(os.getpid())
+    return proc.cpu_percent(), proc.memory_percent()
 
 def get_url_root():
     url_root = flask.request.url_root

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyOpenSSL>=0.15.1
 boto>=2.39.0
 requests>=2.9.1
 redis>=2.10.5
+psutil>=4.1.0


### PR DESCRIPTION
Querying ps binary is not os agnostic. I'm trying to run pritunl under alpine (busybox) for implementing docker container and pritunl fails:

![](https://i.gyazo.com/08175aaf0d92978f2e4e13b1013bbaa7.png)

I suggest to use psutil to fix this bug.
