### PR TITLE
json.loads usage bug

### DIFF
--- a/pritunl/__main__.py
+++ b/pritunl/__main__.py
@@ -151,7 +151,16 @@ def main(default_conf=None):
             group = getattr(settings, group_str)
 
         val_str = args[2]
-        val = json.loads(val_str)
+        """ json.loads is being used to manipulate/validate incoming arguments
+            it doesn't deal with strings that are not already quoted as json strings
+            so if it generates an exception try enconding the value with JSONEncoder
+            we still want to pass in bool/ints directly to json.loads
+        """
+        try:
+            val = json.loads(val_str)
+        except ValueError as e:
+            val = json.loads(json.JSONEncoder().encode(val_str))
+
         setattr(group, key_str, val)
 
         if group_str == 'host':


### PR DESCRIPTION
json.loads is being used to manipulate/validate incoming arguments
it doesn't deal with strings that are not already quoted as json strings
so if it generates an exception try enconding the value with JSONEncoder
we still want to pass in bool/ints directly to json.loads so they become real
json bools/ints

Example error:
```
root@host:~# pritunl set host.sync_address vpn.example.com
Traceback (most recent call last):
  File "/usr/bin/pritunl", line 11, in <module>
    load_entry_point('pritunl==1.25.1103.21', 'console_scripts', 'pritunl')()
  File "/usr/lib/pritunl/local/lib/python2.7/site-packages/pritunl/__main__.py", line 154, in main
    val = json.loads(val_str)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

With this patch:
```
root@host:/var/log# pritunl set host.sync_address vpn.example.com
host.sync_address = "vpn.example.com"
```