### PR TITLE
Fix server handler to check if property is None

### DIFF
--- a/pritunl/handlers/server.py
+++ b/pritunl/handlers/server.py
@@ -274,9 +274,10 @@ def server_put_post(server_id=None):
     search_domain = None
     search_domain_def = False
     if 'search_domain' in flask.request.json:
-        search_domain_def = True
-        search_domain = ', '.join([utils.filter_str(x.strip()) for x in
-            flask.request.json['search_domain'].split(',')])
+        if flask.request.json['search_domain'] is not None:
+            search_domain_def = True
+            search_domain = ', '.join([utils.filter_str(x.strip()) for x in
+                flask.request.json['search_domain'].split(',')])
 
     inter_client = True
     inter_client_def = False


### PR DESCRIPTION
Hi, I recently tried setting up Pritunl on a fresh Ubuntu 14.04 vm. I hit a roadblock when trying to add a server - the web interface only said a server error occurred.

Looking into the logs, it turns out that python was throwing an error:
```
  File "/usr/lib/pritunl/local/lib/python2.7/site-packages/pritunl/handlers/server.py", line 279, in server_put_post
    flask.request.json['search_domain'].split(',')])
```

The request data is as such:
```
{
    ...
    replica_count:1,
    restrict_routes:true,
    search_domain:null,
    status:null,
    ....
}
```

`search_domain` is still a key in the request json, but is `None`. This PR adds a second check to make sure it is not `None` before calling `split` on it.