### PR TITLE
route metric used for identical network_links

### DIFF
--- a/pritunl/server/instance.py
+++ b/pritunl/server/instance.py
@@ -1,6 +1,7 @@
 from pritunl.server.instance_com import ServerInstanceCom
 from pritunl.server.instance_link import ServerInstanceLink
 from pritunl.server.bridge import add_interface, rem_interface
+from pritunl.server.metrics import ServerMetrics
 
 from pritunl.constants import *
 from pritunl.exceptions import *
@@ -28,6 +29,7 @@ import collections
 import pymongo
 
 _resource_locks = collections.defaultdict(threading.Lock)
+_metrics = ServerMetrics()
 
 class ServerInstance(object):
     def __init__(self, server):
@@ -142,20 +144,23 @@ class ServerInstance(object):
                 if ':' in network:
                     push += 'push "route-ipv6 %s net_gateway"\n' % network
                 else:
-                    push += 'push "route %s %s net_gateway"\n' % \
-                        utils.parse_network(network)
+                    network_key = utils.parse_network(network)
+                    metric = _metrics.add_missing_metric(network_key, str(self.server.id))
+                    push += 'push "route %s %s net_gateway %d"\n' % (network_key + (metric,))
             elif not route.get('network_link'):
                 if ':' in network:
                     push += 'push "route-ipv6 %s"\n' % network
                 else:
-                    push += 'push "route %s %s"\n' % utils.parse_network(
-                        network)
+                    network_key = utils.parse_network(network)
+                    metric = _metrics.add_missing_metric(network_key, str(self.server.id))
+                    push += 'push "route %s %s %d"\n' % (network_key + (metric,))
             else:
                 if ':' in network:
                     push += 'route-ipv6 %s %s\n' % (network, gateway6)
                 else:
-                    push += 'route %s %s %s\n' % (utils.parse_network(
-                        network) + (gateway,))
+                    network_key = utils.parse_network(network)
+                    metric = _metrics.add_missing_metric(network_key, str(self.server.id))
+                    push += 'route %s %s %s %d\n' % (network_key + (gateway, metric,))
 
         for link_svr in self.server.iter_links(fields=(
                 '_id', 'network', 'local_networks', 'network_start',
@@ -538,6 +543,8 @@ class ServerInstance(object):
 
     def stop_process(self):
         self.sock_interrupt = True
+
+        _metrics.del_stopped_metric(str(self.server.id))
 
         for instance_link in self.server_links:
             instance_link.stop()

--- a/pritunl/server/metrics.py
+++ b/pritunl/server/metrics.py
@@ -1,0 +1,38 @@
+
+class ServerMetrics(object):
+    def __init__(self):
+        self.metrics_allocated = {}
+        self.metrics_server_map = {}
+
+    def add_missing_metric(self, network_key, server_id):
+        metrics = self.metrics_allocated.get(network_key, [])
+        if len(metrics) == 0:
+            self.metrics_allocated[network_key] = [1]
+            self.metrics_server_map[server_id] = (network_key, 1)
+            return 1
+
+        m = max(metrics)
+
+        missing = sorted(set(range(1, m)).difference(metrics))
+
+        if len(missing) == 0:
+            metrics.append(m + 1)
+            self.metrics_allocated[network_key] = sorted(metrics)
+            self.metrics_server_map[server_id] = (network_key, m + 1)
+            return (m + 1)
+        else:
+            metrics.append(missing[0])
+            self.metrics_allocated[network_key] = sorted(metrics)
+            self.metrics_server_map[server_id] = (network_key, missing[0])
+            return missing[0]
+
+    def del_stopped_metric(self, server_id):
+            network_key, metric = self.metrics_server_map[server_id]
+            metrics = self.metrics_allocated[network_key]
+
+            metrics.remove(metric)
+
+            if len(metrics) == 0:
+                del self.metrics_allocated[network_key]
+
+            del self.metrics_server_map[server_id]


### PR DESCRIPTION
If you have identical network_link / netmask (that is identical routes) it does not work.
In order to enable identical routes over different servers, route metrics can be used.

This request pushes openvpn routes with correct metric in order to manage all the routes even in case with identical routes.

The metric in incremented for each identical route.
When a server is stopped/deleted a hole in the sequence of the route metrics is left. That hole will be correctly filled at the next server creation with identical route, in order to avoid numbers always growing.

Please note that I am not a python developer, I never used python before, I work with other languages, so please have a look at my code.