### PR TITLE
Fix issue with pritunl set KEY Value comamnd where VALUE has hyphens

### DIFF
--- a/pritunl/__main__.py
+++ b/pritunl/__main__.py
@@ -45,6 +45,8 @@ def main(default_conf=None):
             help='Tail log file')
         parser.add_option('--limit', type='int',
             help='Limit log lines')
+    elif cmd == 'set':
+        parser.disable_interspersed_args()
 
     (options, args) = parser.parse_args()
 


### PR DESCRIPTION
This patch resolves the issue when trying to set a configuration value using the `pritunl set KEY VALUE` command.  Python's opt parse interprets the value as an option to parse and errors with an unknown option error.
```
pritunl set app.sso_saml_cert "-----BEGIN CERTIF.....
age: pritunl [command] [options]
Command Help: pritunl [command] --help

Commands:
  start                 Start server
  version               Print the version and exit


  setup-key             Print the setup key and exit


import pritunl
  reset-password        Reset administrator password
  reset-version         Reset database version to server version
  reset-ssl-cert        Reset the server ssl certificate
  reconfigure           Reconfigure database connection
  set-mongodb           Set the mongoldb uri
  logs                  View server logs

pritunl: error: no such option: -----BEGIN CERTIFIC......
```
Enabling `parser.disable_interspersed_args()` causes optparse to stop at the first unrecognized option.  This works for the `set` command because the positional arguments are not processed through optparse (for better or worse).

Rewriting the parsing logic so the positional parameters are opt parsed would probably be a better long term solution, but for now this patches the immediate issue.

```
root@vpnofawesomeness:~# pritunl set app.sso_saml_cert "-----BEGIN CERTIFICATE-----...-----END CERTIFICATE-----"
app.sso_saml_cert = "-----BEGIN CERTIFICATE-----...---END CERTIFICATE-----"

```
