### PR TITLE
Filters out route tables that have None for id

### DIFF
--- a/pritunl/utils/aws.py
+++ b/pritunl/utils/aws.py
@@ -1,11 +1,11 @@
-from pritunl.exceptions import *
-from pritunl.constants import *
 from pritunl import settings
+from pritunl.constants import *
+from pritunl.exceptions import *
 
 import boto
 import boto.ec2
-import boto.vpc
 import boto.route53
+import boto.vpc
 import requests
 
 def connect_vpc(aws_key, aws_secret, region):
@@ -46,7 +46,10 @@ def add_vpc_route(region, vpc_id, network, resource_id):
 
     vpc_conn = connect_vpc(aws_key, aws_secret, region)
 
-    tables = vpc_conn.get_all_route_tables(filters={'vpc-id': vpc_id})
+    tables = filter(
+        lambda r: r.id,
+        vpc_conn.get_all_route_tables(filters={'vpc-id': vpc_id})
+    )
     if not tables:
         raise VpcRouteTableNotFound('Failed to find VPC routing table')
 


### PR DESCRIPTION
Somehow, boto is not parsing the xml returned from AWS correctly. I can't seem to identify anything special about the route table that it's messing up. It is of the same form as everything else. The only thing that differentiates it is that it has almost 100 routes. Perhaps the parser boto uses gives up at that point?

I'm unsure. I tried digging into the boto code, but came out completely flummoxed.

I didn't notice my text editor had altered the file until I was writing this PR. If you'd prefer I don't change the style, I can go back and update this PR. Let me know if there's anything you'd like me to add (tests?).