### PR TITLE
this swaps the calls to the vpc create_route and replace_route.

### DIFF
--- a/pritunl/utils/aws.py
+++ b/pritunl/utils/aws.py
@@ -67,14 +67,14 @@ def add_vpc_route(region, vpc_id, network, resource_id):
             continue
 
         try:
-            vpc_conn.create_route(
+            vpc_conn.replace_route(
                 table.id,
                 network,
                 instance_id=instance_id,
                 interface_id=interface_id,
             )
         except:
-            vpc_conn.replace_route(
+            vpc_conn.create_route(
                 table.id,
                 network,
                 instance_id=instance_id,


### PR DESCRIPTION
create_route would only be called whenever new networks/server links are added
for the very first time to a table.

replace_route however would be called any time a vpn service is stopped/started,
a failover occurs, etc

when pritunl encounters the ec2 api limit issue, this issue is compounded as
pritunl bails out, leaving dangling routes that will need to be replaced on next
startup.

by swapping the order we should see a 50% decrease in api calls for existing
services/routes.  the trade off being the first time you add something, 2 calls occur.