### PR TITLE
Google SSO domain matching

### DIFF
--- a/pritunl/sso/google.py
+++ b/pritunl/sso/google.py
@@ -2,4 +2,7 @@ from pritunl import settings
 
 def verify_google(user_email):
     user_domain = user_email.split('@')[-1]
-    return user_domain in settings.app.sso_match
+    match = False
+    for d in settings.app.sso_match:
+        if d == user_domain: match = True
+    return match


### PR DESCRIPTION
The existing function will successfully match on any domain that is a subset of the true Google SSO domain. For example, if sso_domains contains "example.com", the function will allow users to register with "ample.com" email addresses.