### PR TITLE
Fix OpenVPN configuration plugin hook

### DIFF
--- a/pritunl/server/instance.py
+++ b/pritunl/server/instance.py
@@ -332,7 +332,7 @@ class ServerInstance(object):
                 for return_val in returns:
                     if not return_val:
                         continue
-                    server_conf += return_val.strip() + '/n'
+                    server_conf += return_val.strip() + '\n'
 
         server_conf += '<ca>\n%s\n</ca>\n' % self.server.ca_certificate
 


### PR DESCRIPTION
When calling server_config() on a plugin, the output is concatenated using a 
newline. Except in this case the newline was `/n` instead of `\n`.