### PR TITLE
Fixed error displaying an exception from user plugin

### DIFF
--- a/pritunl/plugins/plugins.py
+++ b/pritunl/plugins/plugins.py
@@ -66,9 +66,7 @@ def _event(event_type, **kwargs):
         try:
             handler(**kwargs)
         except:
-            logger.exception('Error in plugin handler', 'plugins',
-                event_type=event_type,
-            )
+            logger.exception('Error in plugin handler', 'plugins')
 
 def event(event_type, **kwargs):
     if not settings.local.sub_plan or \


### PR DESCRIPTION
Correcting this problem:
![image](https://user-images.githubusercontent.com/998319/37800043-a66656ac-2e32-11e8-9c42-8dbf38fc6bb6.png)

Original exception is not shown. Since error occurs elsewhere.
