### PR TITLE
Improve iptable sorting

### DIFF
--- a/pritunl/iptables.py
+++ b/pritunl/iptables.py
@@ -816,16 +816,13 @@ class Iptables(object):
             cidr = int(route.split('/')[-1])
             sorted_routes6[cidr].append(route)
 
-        sorted_nat_routes = collections.defaultdict(list)
-        sorted_nat_routes6 = collections.defaultdict(list)
-
         for route, interface in self._nat_routes.items():
             if route == '0.0.0.0/0':
                 all_interface = interface
                 continue
 
             cidr = int(route.split('/')[-1])
-            sorted_nat_routes[cidr].append((route, interface))
+            sorted_routes[cidr].append((route, interface))
 
         for route, interface in self._nat_routes6.items():
             if route == '::/0':
@@ -833,7 +830,7 @@ class Iptables(object):
                 continue
 
             cidr = int(route.split('/')[-1])
-            sorted_nat_routes6[cidr].append((route, interface))
+            sorted_routes6[cidr].append((route, interface))
 
         if self._accept_all and all_interface:
             for nat_network in self._nat_networks:
@@ -869,82 +866,83 @@ class Iptables(object):
                         '-j', 'MASQUERADE',
                     ])
 
-        for cidr in sorted(sorted_nat_routes.keys()):
-            for route, interface in sorted_nat_routes[cidr]:
-                for nat_network in self._nat_networks:
-                    if settings.vpn.lib_iptables and LIB_IPTABLES:
-                        rule = self._init_rule()
-                        rule.src = nat_network
-                        rule.dst = route
-                        rule.out_interface = interface
-                        rule.create_target('MASQUERADE')
-                        self._accept.append(('POSTROUTING', rule))
-                    else:
-                        self._accept.append([
-                            'POSTROUTING',
-                            '-t', 'nat',
-                            '-s', nat_network,
-                            '-d', route,
-                            '-o', interface,
-                            '-j', 'MASQUERADE',
-                        ])
-
-        for cidr in sorted(sorted_nat_routes6.keys()):
-            for route, interface in sorted_nat_routes6[cidr]:
-                for nat_network in self._nat_networks6:
-                    if settings.vpn.lib_iptables and LIB_IPTABLES:
-                        rule = self._init_rule6()
-                        rule.src = nat_network
-                        rule.dst = route
-                        rule.out_interface = interface
-                        rule.create_target('MASQUERADE')
-                        self._accept6.append(('POSTROUTING', rule))
-                    else:
-                        self._accept6.append([
-                            'POSTROUTING',
-                            '-t', 'nat',
-                            '-s', nat_network,
-                            '-d', route,
-                            '-o', interface,
-                            '-j', 'MASQUERADE',
-                        ])
-
         for cidr in sorted(sorted_routes.keys()):
-            for route in sorted_routes[cidr]:
-                for nat_network in self._nat_networks:
-                    if settings.vpn.lib_iptables and LIB_IPTABLES:
-                        rule = self._init_rule()
-                        rule.src = nat_network
-                        rule.dst = route
-                        rule.create_target('ACCEPT')
-                        self._accept.append(('POSTROUTING', rule))
-                    else:
-                        self._accept.append([
-                            'POSTROUTING',
-                            '-t', 'nat',
-                            '-s', nat_network,
-                            '-d', route,
-                            '-j', 'ACCEPT',
-                        ])
+            for entry in sorted(sorted_routes[cidr], key=lambda x: x[0]):
+                if (isinstance(entry, basestring)):
+                    route = entry
+                    for nat_network in self._nat_networks:
+                        if settings.vpn.lib_iptables and LIB_IPTABLES:
+                            rule = self._init_rule()
+                            rule.src = nat_network
+                            rule.dst = route
+                            rule.create_target('ACCEPT')
+                            self._accept.append(('POSTROUTING', rule))
+                        else:
+                            self._accept.append([
+                                'POSTROUTING',
+                                '-t', 'nat',
+                                '-s', nat_network,
+                                '-d', route,
+                                '-j', 'ACCEPT',
+                            ])
+                elif (isinstance(entry, tuple) and len(entry) == 2):
+                    route,interface = entry
+                    for nat_network in self._nat_networks:
+                        if settings.vpn.lib_iptables and LIB_IPTABLES:
+                            rule = self._init_rule()
+                            rule.src = nat_network
+                            rule.dst = route
+                            rule.out_interface = interface
+                            rule.create_target('MASQUERADE')
+                            self._accept.append(('POSTROUTING', rule))
+                        else:
+                            self._accept.append([
+                                'POSTROUTING',
+                                '-t', 'nat',
+                                '-s', nat_network,
+                                '-d', route,
+                                '-o', interface,
+                                '-j', 'MASQUERADE',
+                            ])
 
         for cidr in sorted(sorted_routes6.keys()):
-            for route in sorted_routes6[cidr]:
-                for nat_network in self._nat_networks6:
-                    if settings.vpn.lib_iptables and LIB_IPTABLES:
-                        rule = self._init_rule6()
-                        rule.src = nat_network
-                        rule.dst = route
-                        rule.create_target('ACCEPT')
-                        self._accept6.append(('POSTROUTING', rule))
-                    else:
-                        self._accept6.append([
-                            'POSTROUTING',
-                            '-t', 'nat',
-                            '-s', nat_network,
-                            '-d', route,
-                            '-j', 'ACCEPT',
-                        ])
-
+            for entry in sorted(sorted_routes[cidr], key=lambda x: x[0]):
+                if (isinstance(entry, basestring)):
+                    route = entry
+                    for nat_network in self._nat_networks6:
+                        if settings.vpn.lib_iptables and LIB_IPTABLES:
+                            rule = self._init_rule6()
+                            rule.src = nat_network
+                            rule.dst = route
+                            rule.create_target('ACCEPT')
+                            self._accept6.append(('POSTROUTING', rule))
+                        else:
+                            self._accept6.append([
+                                'POSTROUTING',
+                                '-t', 'nat',
+                                '-s', nat_network,
+                                '-d', route,
+                                '-j', 'ACCEPT',
+                            ])
+                elif (isinstance(entry, tuple) and len(entry) == 2):
+                    route,interface = entry
+                    for nat_network in self._nat_networks6:
+                        if settings.vpn.lib_iptables and LIB_IPTABLES:
+                            rule = self._init_rule6()
+                            rule.src = nat_network
+                            rule.dst = route
+                            rule.out_interface = interface
+                            rule.create_target('MASQUERADE')
+                            self._accept6.append(('POSTROUTING', rule))
+                        else:
+                            self._accept6.append([
+                                'POSTROUTING',
+                                '-t', 'nat',
+                                '-s', nat_network,
+                                '-d', route,
+                                '-o', interface,
+                                '-j', 'MASQUERADE',
+                            ])
     def generate(self):
         if self.cleared:
             return


### PR DESCRIPTION
Current sorting method does all ACCEPT rules and then all MASQ rules.  This can
lead to mismatch issues, if you need a subset of a network to have one behavior
while the rest of the network needs the other.

For example, say you need:
* `172.16.1.2/32` to be NAT'd 
* `172.16.1.0/24` to not be NAT'd.  

The current code would lay the rules down as:

```
Chain POSTROUTING (policy ACCEPT)
num  target     prot opt source               destination
1     all  --  172.30.1.0/24        172.16.0.0/24        /* pritunl-583c953f26365b65dbfd2c59 */
2     all  --  172.30.1.0/24        172.16.1.0/24        /* pritunl-583c953f26365b65dbfd2c59 */
3     all  --  172.30.1.0/24        172.31.0.0/16        /* pritunl-583c953f26365b65dbfd2c59 */
4    MASQUERADE  all  --  172.30.1.0/24        172.16.1.2           /* pritunl-583c953f26365b65dbfd2c59 */
5    MASQUERADE  all  --  172.30.1.0/24        10.0.0.0/8           /* pritunl-583c953f26365b65dbfd2c59 */
6    MASQUERADE  all  --  172.30.1.0/24        0.0.0.0/0            /* pritunl-583c953f26365b65dbfd2c59 */
```

This results in `172.16.1.2/32` **not** being NAT'd, as it will match on the rule at line **2** and never get to the rule on line **4**.  This patch fixes that by collapse the route arrays.

Results after this patch:

```
Chain POSTROUTING (policy ACCEPT)
num  target     prot opt source               destination
1    MASQUERADE  all  --  172.30.1.0/24        172.16.1.2           /* pritunl-583c953f26365b65dbfd2c59 */
2    ACCEPT     all  --  172.30.1.0/24        172.16.0.0/24        /* pritunl-583c953f26365b65dbfd2c59 */
3    ACCEPT     all  --  172.30.1.0/24        172.16.1.0/24        /* pritunl-583c953f26365b65dbfd2c59 */
4    ACCEPT     all  --  172.30.1.0/24        172.31.0.0/16        /* pritunl-583c953f26365b65dbfd2c59 */
5    MASQUERADE  all  --  172.30.1.0/24        10.0.0.0/8           /* pritunl-583c953f26365b65dbfd2c59 */
6    MASQUERADE  all  --  172.30.1.0/24        0.0.0.0/0            /* pritunl-583c953f26365b65dbfd2c59 */
```
This provides the rule order.
