### PR TITLE
route is a dict

### DIFF
--- a/pritunl/server/server.py
+++ b/pritunl/server/server.py
@@ -1468,7 +1468,7 @@ class Server(mongo.MongoObject):
 
             routes_set = set()
             for route in link_svr.get_routes():
-                if route != '0.0.0.0/0':
+                if route['network'] != '0.0.0.0/0':
                     routes_set.add(route['network'])
             if routes & routes_set:
                 return SERVER_LINK_COMMON_ROUTE, SERVER_LINK_COMMON_ROUTE_MSG

--- a/pritunl/server/utils.py
+++ b/pritunl/server/utils.py
@@ -169,7 +169,8 @@ def link_servers(server_id, link_server_id, use_local_address=False):
 
         routes_set = set()
         for route in svr.get_routes():
-            routes_set.add(route['network'])
+            if route['network'] != '0.0.0.0/0':
+                routes_set.add(route['network'])
         if routes & routes_set:
             return SERVER_LINK_COMMON_ROUTE, SERVER_LINK_COMMON_ROUTE_MSG
         routes.update(routes_set)


### PR DESCRIPTION
the `route` variable is a dict, so we need to reference the `network` key else the comparison is always false.

