### PR TITLE
Encode strings with utf-8 if using python3.x

### DIFF
--- a/tools/add_aws_ranges.py
+++ b/tools/add_aws_ranges.py
@@ -5,6 +5,7 @@ import hmac
 import hashlib
 import base64
 import json
+import sys
 
 BASE_URL = 'https://server.domain'
 API_TOKEN = 'Hv2FxEMoa3moTVuRahMsMK3VUCwdmjmt'
@@ -40,8 +41,12 @@ def auth_request(method, path, headers=None, data=None):
     auth_nonce = uuid.uuid4().hex
     auth_string = '&'.join([API_TOKEN, auth_timestamp, auth_nonce,
         method.upper(), path])
-    auth_signature = base64.b64encode(hmac.new(
-        API_SECRET, auth_string, hashlib.sha256).digest())
+    if sys.version_info[0] < 3:
+        auth_signature = base64.b64encode(hmac.new(
+            API_SECRET, auth_string, hashlib.sha256).digest())
+    else:
+        auth_signature = base64.b64encode(hmac.new(
+            API_SECRET.encode('utf-8'), auth_string.encode('utf-8'), hashlib.sha256).digest())
     auth_headers = {
         'Auth-Token': API_TOKEN,
         'Auth-Timestamp': auth_timestamp,


### PR DESCRIPTION
Adding a conditional for running this script in `python3.x`. When using `python3.x`, the `b64.encode` function requires `bytes` or `bytearray` instead of `str`.

Using the script in `python3.x` without encoding the string yields the following:
```
Traceback (most recent call last):
  File "add_aws_ranges.py", line 100, in <module>
    data=json.dumps(routes),
  File "add_aws_ranges.py", line 48, in auth_request
    hashlib.sha256).digest())
  File "/Users/jsmith/.pyenv/versions/3.6.3/lib/python3.6/hmac.py", line 144, in new
    return HMAC(key, msg, digestmod)
  File "/Users/jsmith/.pyenv/versions/3.6.3/lib/python3.6/hmac.py", line 42, in __init__
    raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
TypeError: key: expected bytes or bytearray, but got 'str'
```

Links:
- https://stackoverflow.com/questions/31848293/python3-and-hmac-how-to-handle-string-not-being-binary
- https://stackoverflow.com/questions/9079036/detect-python-version-at-runtime