### PR TITLE
Removes IgnoreDefaultRoute from chrome ONC

### DIFF
--- a/pritunl/user/user.py
+++ b/pritunl/user/user.py
@@ -856,9 +856,8 @@ class User(mongo.MongoObject):
             server_ref += '            "%s",\n' % cert_id
         server_ref = server_ref[:-2]
 
-        if svr.is_route_all():
-            other = '\n          "IgnoreDefaultRoute": false,'
-        else:
+        other = ''
+        if not svr.is_route_all():
             other = '\n          "IgnoreDefaultRoute": true,'
 
         password_mode = self._get_password_mode(svr)


### PR DESCRIPTION
We had discussed this on 10 September 2018 and a patch was put through,
and I confirmed it had fixed our issues after it went live, but this
week it occurred to me I had tested my own code and not the patch you'd
put through. As such, full tunnel connections still aren't working
correctly. We realized this after upgrading to the latest Pritunl. This
patch is what is on our Pritunl web host now.

On 13 September 2018, you said:
> I don't think it will work but there isn't a significant use case for
> routing all traffic on Chrome OS so it isn't something that I plan on
> fixing.

You were correct, it didn't work, since the patch (https://github.com/pritunl/pritunl/commit/8e02657fcc1fc407307d5d2a84c19e83f990921b) didn't follow the
instructions Google had given us:
> On client side you need to remove
> "IgnoreDefaultRoute": true,
> Line from ONC file.

Instead of removing the line, the previous patch changed `true` to
`false`. This patch removes the line altogether, which I can confirm
fixes the problem. 

As always, I appreciate your support.