### PR TITLE
Up the default DH param size to 2048 bits

### DIFF
--- a/pritunl/settings/app.py
+++ b/pritunl/settings/app.py
@@ -64,7 +64,7 @@ class SettingsApp(SettingsGroupMongo):
         'user_pool_size': 6,
         'server_pool_size': 4,
         'server_user_pool_size': 2,
-        'dh_param_bits_pool': [1536],
+        'dh_param_bits_pool': [2048],
         'cookie_secret': None,
         'cookie_secret2': None,
         'email_server': None,

--- a/pritunl/settings/vpn.py
+++ b/pritunl/settings/vpn.py
@@ -10,7 +10,7 @@ class SettingsVpn(SettingsGroupMongo):
         'client_ttl': 300,
         'peer_limit': 300,
         'peer_limit_timeout': 10,
-        'default_dh_param_bits': 1536,
+        'default_dh_param_bits': 2048,
         'otp_cache': True,
         'otp_cache_timeout': 28800,
         'log_lines': 5000,

--- a/www/views/modalAddServer.js
+++ b/www/views/modalAddServer.js
@@ -23,7 +23,7 @@ define([
         'network': this._get_free_network(),
         'port': this._get_free_port(),
         'protocol': 'udp',
-        'dh_param_bits': 1536,
+        'dh_param_bits': 2048,
         'ipv6_firewall': true,
         'dns_servers': ['8.8.8.8'],
         'cipher': 'aes128',


### PR DESCRIPTION
This is what the documentation states is needed in order to set up a secure VPN
server, so let's make it the default:
https://docs.pritunl.com/docs/securing-pritunl