### PR TITLE
Dropping space in comma separator for `json.dumps`

### DIFF
--- a/pritunl/user/user.py
+++ b/pritunl/user/user.py
@@ -693,7 +693,9 @@ class User(mongo.MongoObject):
             data['sync_token'] = self.sync_token
             data['sync_secret'] = self.sync_secret
 
-        return '#' + json.dumps(data, indent=1).replace('\n', '\n#')
+        return "#" + json.dumps(
+            data, indent=1, separators=(",", ": ")
+        ).replace("\n", "\n#")
 
     def _generate_conf(self, svr, include_user_cert=True):
         if not self.sync_token or not self.sync_secret:


### PR DESCRIPTION
I noticed that the generated profiles have some lines with trailing
whitespace and tracked down this line.

To compare:

```python
>>> import json
>>> json.dumps({'a': 'b', 'c': 'd'}, indent=1)
'{\n "a": "b", \n "c": "d"\n}'
>>> json.dumps({'a': 'b', 'c': 'd'}, indent=1, separators=(',', ': '))
'{\n "a": "b",\n "c": "d"\n}'
>>> import sys
>>> sys.version
'2.7.15 ...'
```

Also note that this is not an issue on Python 3.7.