### PR TITLE
SELinux: add boolean domain_can_mmap_files to pritunl_t

### DIFF
--- a/selinux/pritunl.te
+++ b/selinux/pritunl.te
@@ -108,6 +108,7 @@ allow pritunl_t pritunl_dns_exec_t:file { execute open read };
 allow pritunl_t self:fifo_file rw_fifo_file_perms;
 allow pritunl_t self:unix_stream_socket { create_stream_socket_perms connectto };
 
+domain_can_mmap_files(pritunl_t)
 domain_use_interactive_fds(pritunl_t)
 files_read_etc_files(pritunl_t)
 miscfiles_read_localization(pritunl_t)


### PR DESCRIPTION
Since boolean domain_can_mmap_files has been added to SELinux-policy,
commands executed with pritunl_t type gets denied by SELinux.
(Detailed journalctl log: https://git.io/fjZvO)

As from the package changelog from below,
https://centos.pkgs.org/7/centos-x86_64/selinux-policy-3.13.1-229.el7.noarch.rpm.html

we can find that domain_can_mmap_files boolean has been added 
at 2018-09-07 with package version 3.13.1-224.

This commit adds domain_can_mmap_files boolean to pritunl_t to fix this issue.