### PR TITLE
[DOC] Using http instead of https for Ubuntu Xenial since package apt-transport-https is not installed by default there.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ sudo systemctl enable mongod pritunl
 
 ```bash
 sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list << EOF
-deb https://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse
+deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/4.0 multiverse
 EOF
 
 sudo tee /etc/apt/sources.list.d/pritunl.list << EOF


### PR DESCRIPTION
No need to worry about security, though, as there'd still be validations based on signatures.