### PR TITLE
Remove deprecated option `max-routes`

### DIFF
--- a/pritunl/constants.py
+++ b/pritunl/constants.py
@@ -1150,7 +1150,6 @@ server-poll-timeout 4
 reneg-sec 2592000
 sndbuf 393216
 rcvbuf 393216
-max-routes 1000
 remote-cert-tls server
 """
 
@@ -1250,7 +1249,6 @@ server-poll-timeout 4
 reneg-sec 2592000
 sndbuf 393216
 rcvbuf 393216
-max-routes 1000
 remote-cert-tls server
 """
 


### PR DESCRIPTION
This option is deprecated and can be removed. Following warning is given in the client logs:
```
DEPRECATED OPTION: --max-routes option ignored.The number of routes is unlimited as of OpenVPN 2.4. This option will be removed in a future version, please remove it from your configuration.
```