### PR TITLE
Fixed script for debian buster with MongoDB 4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,20 +187,20 @@ sudo systemctl enable mongodb pritunl
 ### debian buster
 
 ```bash
-sudo tee /etc/apt/sources.list.d/mongodb-org-4.0.list << EOF
-deb https://repo.mongodb.org/apt/debian buster/mongodb-org/4.0 main
+sudo tee /etc/apt/sources.list.d/mongodb-org-4.2.list << EOF
+deb https://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main
 EOF
 
 sudo tee /etc/apt/sources.list.d/pritunl.list << EOF
 deb https://repo.pritunl.com/stable/apt buster main
 EOF
 
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 9DA31620334BD75D9DCB49F368818C72E52529D4
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv E162F504A20CDF15827F718D4B7C549A058F8B6B
 sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com --recv 7568D9BB55FF9E5287D586017AE645C0CF8E292A
 sudo apt-get update
-sudo apt-get --assume-yes install pritunl mongodb-server
-sudo systemctl start mongodb pritunl
-sudo systemctl enable mongodb pritunl
+sudo apt-get --assume-yes install pritunl mongodb-org-server
+sudo systemctl start mongod pritunl
+sudo systemctl enable mongod pritunl
 ```
 
 ### oracle linux 7


### PR DESCRIPTION
Fixed script for debian buster with MongoDB 4.2 from the specified repo (4.0 is not available anymore)