### PR TITLE
Added advanced error handling at subscription.py

### DIFF
--- a/pritunl/handlers/subscription.py
+++ b/pritunl/handlers/subscription.py
@@ -32,7 +32,10 @@ def subscription_styles_get(plan, ver):
         styles = settings.local.sub_styles[plan]
     except KeyError:
         subscription.update()
-        styles = settings.local.sub_styles[plan]
+        try:
+                styles = settings.local.sub_styles[plan]
+        except KeyError:
+                styles = {'etag' : 0, 'last_modified' : 0, 'data' : ''}
 
     return utils.styles_response(
         styles['etag'],


### PR DESCRIPTION
...in case the browser still uses the old plan and tries to ask the server for the old styles. This will prevent any exceptions thrown on the server console and just answers the request with a default value...