### PR TITLE
add txqueuelen to server config

### DIFF
--- a/pritunl/constants.py
+++ b/pritunl/constants.py
@@ -1125,6 +1125,7 @@ rcvbuf 393216
 reneg-sec 2592000
 hash-size 1024 1024
 max-routes-per-client 1000
+txqueuelen 1000
 verb %s
 mute %s
 """
@@ -1154,6 +1155,7 @@ rcvbuf 393216
 reneg-sec 2592000
 hash-size 1024 1024
 max-routes-per-client 1000
+txqueuelen 1000
 verb %s
 mute %s
 """


### PR DESCRIPTION
txqueuelen defaults to 100 on openvpn,   changing it to 1000 has a large performance throughput increase on the clients.   I have been running it with this patched in for several months with no issues. 

here is a reference for more details
https://ivanvari.com/solving-openvpn-poor-throughput-and-packet-loss/