### PR TITLE
fixed the parameters for MongoObject

### DIFF
--- a/pritunl/auth/administrator.py
+++ b/pritunl/auth/administrator.py
@@ -44,7 +44,7 @@ class Administrator(mongo.MongoObject):
     def __init__(self, username=None, password=None, default=None,
             yubikey_id=None, otp_auth=None, auth_api=None, disabled=None,
             super_user=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         if username is not None:
             self.username = username
         if password is not None:

--- a/pritunl/host/host.py
+++ b/pritunl/host/host.py
@@ -43,7 +43,7 @@ class Host(mongo.MongoObject):
     }
 
     def __init__(self, name=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         self.user_count = None
         self.users_online = None
         self.usage = HostUsage(self.id)

--- a/pritunl/link/link.py
+++ b/pritunl/link/link.py
@@ -40,7 +40,7 @@ class Host(mongo.MongoObject):
             timeout=None, priority=None, ping_timestamp_ttl=None,
             static=None, public_address=None, local_address=None,
             address6=None, version=None, tunnels=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         self.link = link
         self.location = location
@@ -567,7 +567,7 @@ class Location(mongo.MongoObject):
 
     def __init__(self, link=None, name=None, type=None, link_id=None,
             routes=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         self.link = link
 
@@ -885,7 +885,7 @@ class Link(mongo.MongoObject):
 
     def __init__(self, name=None, type=None, status=None, timeout=None,
             key=None, ipv6=None, action=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         if name is not None:
             self.name = name

--- a/pritunl/logger/entry.py
+++ b/pritunl/logger/entry.py
@@ -12,7 +12,7 @@ class LogEntry(mongo.MongoObject):
     }
 
     def __init__(self, message=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         if message is not None:
             self.message = message

--- a/pritunl/organization/organization.py
+++ b/pritunl/organization/organization.py
@@ -36,7 +36,7 @@ class Organization(mongo.MongoObject):
     }
 
     def __init__(self, name=None, auth_api=None, type=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         self.last_search_count = None
         self.processes = []
         self.queue_com = queue.QueueCom()

--- a/pritunl/queue/queue.py
+++ b/pritunl/queue/queue.py
@@ -39,7 +39,7 @@ class Queue(mongo.MongoObject):
     reserve_id = None
 
     def __init__(self, priority=None, retry=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         self.ttl = settings.mongo.queue_ttl
         self.type = self.type
         self.reserve_id = self.reserve_id

--- a/pritunl/server/server.py
+++ b/pritunl/server/server.py
@@ -215,7 +215,7 @@ class Server(mongo.MongoObject):
             allowed_devices=None, max_clients=None, max_devices=None,
             replica_count=None, vxlan=None, dns_mapping=None, debug=None,
             pre_connect_msg=None, mss_fix=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         if 'network' in self.loaded_fields:
             self._orig_network = self.network

--- a/pritunl/task.py
+++ b/pritunl/task.py
@@ -31,7 +31,7 @@ class Task(mongo.MongoObject):
     type = None
 
     def __init__(self, run_id=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         self.type = self.type
         self.runner_id = utils.ObjectId()
 

--- a/pritunl/transaction/transaction.py
+++ b/pritunl/transaction/transaction.py
@@ -30,7 +30,7 @@ class Transaction(mongo.MongoObject):
     }
 
     def __init__(self, lock_id=None, priority=None, ttl=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
         self.ttl = settings.mongo.tran_ttl
 
         if lock_id is not None:

--- a/pritunl/user/user.py
+++ b/pritunl/user/user.py
@@ -70,7 +70,7 @@ class User(mongo.MongoObject):
             resource_id=None, bypass_secondary=None, client_to_client=None,
             mac_addresses=None, dns_servers=None, dns_suffix=None,
             port_forwarding=None, **kwargs):
-        mongo.MongoObject.__init__(self, **kwargs)
+        mongo.MongoObject.__init__(self)
 
         if org:
             self.org = org


### PR DESCRIPTION
According to https://github.com/pritunl/pritunl/blob/master/pritunl/mongo/object.py

There is no extra parameters for `MongoObject.__init__`.

Also, this causes errors when migrating to python 3:
```
TypeError: object.__init__() takes exactly one argument (the instance to initialize)
```