### PR TITLE
added __lt__ to queue.Queue

### DIFF
--- a/pritunl/queue/queue.py
+++ b/pritunl/queue/queue.py
@@ -53,6 +53,9 @@ class Queue(mongo.MongoObject):
         if retry is not None:
             self.retry = retry
 
+    def __lt__(self, other):
+        return self.runner_id < other.runner_id
+
     @cached_static_property
     def collection(cls):
         return mongo.get_collection('queue')


### PR DESCRIPTION
`__lt__` is required by `heappop` but it's not properly defined.

Although the project works without it with python 2,
it's causing errors for all class inherit from this class with python 3.