### PR TITLE
add feature to add openvpn scripts for up, down and learn-address

### DIFF
--- a/pritunl/server/instance.py
+++ b/pritunl/server/instance.py
@@ -284,6 +284,15 @@ class ServerInstance(object):
         else:
             raise ValueError('Unknown protocol')
 
+        if os.path.isfile('/etc/openvpn/up.sh'):
+            server_line += '\nup /etc/openvpn/up.sh'
+
+        if os.path.isfile('/etc/openvpn/down.sh'):
+            server_line += '\ndown /etc/openvpn/down.sh'
+
+        if os.path.isfile('/etc/openvpn/learn.sh'):
+            server_line += '\nlearn-address /etc/openvpn/learn.sh'
+
         if utils.check_openvpn_ver():
             server_ciphers = SERVER_CIPHERS
             server_conf_template = OVPN_INLINE_SERVER_CONF


### PR DESCRIPTION
We are running an enterprise setup with 3 hosts and round-robin connections to the servers.
Al our devices have a network link, and to make sure the routing uses the correct server we are using OSPF, but for this to fully work correctly we need to trigger some actions on up and learn-address.

i figured this would be the fastest way to enable this feature without adding a bunch of extra config options in the web interface.

i'm not sure if the files should be in /etc/openvpn/ maybe /etc/pritunl/ is a better location.
Or even just directly in /etc/ as /etc/pritunl-up.sh etc.