### PR TITLE
Update acme_tiny to support LetsEncrypt Staging

### DIFF
--- a/pritunl/acme_tiny.py
+++ b/pritunl/acme_tiny.py
@@ -11,7 +11,7 @@ except ImportError:
 #DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
 #DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"
 
-def get_crt(account_key, csr, set_acme, contact=None):
+def get_crt(account_key, csr, set_acme, contact=None, disable_check=False):
     directory, acct_headers, alg, jwk = None, None, None, None # global variables
 
     # helper functions - base64 encode for jose spec
@@ -31,13 +31,13 @@ def get_crt(account_key, csr, set_acme, contact=None):
         try:
             resp = urlopen(Request(url, data=data, headers={"Content-Type": "application/jose+json", "User-Agent": "acme-tiny"}))
             resp_data, code, headers = resp.read().decode("utf8"), resp.getcode(), resp.headers
-            try:
-                resp_data = json.loads(resp_data) # try to parse json results
-            except ValueError:
-                pass # ignore json parsing errors
         except IOError as e:
             resp_data = e.read().decode("utf8") if hasattr(e, "read") else str(e)
             code, headers = getattr(e, "code", None), {}
+        try:
+            resp_data = json.loads(resp_data) # try to parse json results
+        except ValueError:
+            pass # ignore json parsing errors
         if depth < 100 and code == 400 and json.loads(resp_data)['type'] == "urn:ietf:params:acme:error:badNonce":
             raise IndexError(resp_data) # allow 100 retrys for bad nonces
         if code not in [200, 201, 204]:
@@ -46,7 +46,7 @@ def get_crt(account_key, csr, set_acme, contact=None):
 
     # helper function - make signed requests
     def _send_signed_request(url, payload, err_msg, depth=0):
-        payload64 = _b64(json.dumps(payload).encode('utf8'))
+        payload64 = "" if payload is None else _b64(json.dumps(payload).encode('utf8'))
         new_nonce = _do_request(directory['newNonce'])[2]['Replay-Nonce']
         protected = {"url": url, "alg": alg, "nonce": new_nonce}
         protected.update({"jwk": jwk} if acct_headers is None else {"kid": acct_headers['Location']})
@@ -61,12 +61,12 @@ def get_crt(account_key, csr, set_acme, contact=None):
 
     # helper function - poll until complete
     def _poll_until_not(url, pending_statuses, err_msg):
-        while True:
-            result, _, _ = _do_request(url, err_msg=err_msg)
-            if result['status'] in pending_statuses:
-                time.sleep(2)
-                continue
-            return result
+        result, t0 = None, time.time()
+        while result is None or result['status'] in pending_statuses:
+            assert (time.time() - t0 < 3600), "Polling timeout" # 1 hour timeout
+            time.sleep(0 if result is None else 2)
+            result, _, _ = _send_signed_request(url, None, err_msg)
+        return result
 
     # parse account key to get public key
     logger.info("Parsing account key...")
@@ -91,7 +91,7 @@ def get_crt(account_key, csr, set_acme, contact=None):
     common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", out.decode('utf8'))
     if common_name is not None:
         domains.add(common_name.group(1))
-    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
+    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: (?:critical)?\n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):
             if san.startswith("DNS:"):
@@ -121,7 +121,7 @@ def get_crt(account_key, csr, set_acme, contact=None):
 
     # get the authorizations that need to be completed
     for auth_url in order['authorizations']:
-        authorization, _, _ = _do_request(auth_url, err_msg="Error getting challenges")
+        authorization, _, _ = _send_signed_request(auth_url, None, "Error getting challenges")
         domain = authorization['identifier']['value']
         logger.info("Verifying {0}...".format(domain))
 
@@ -130,6 +130,13 @@ def get_crt(account_key, csr, set_acme, contact=None):
         token = re.sub(r"[^A-Za-z0-9_\-]", "_", challenge['token'])
         keyauthorization = "{0}.{1}".format(token, thumbprint)
         set_acme(token, keyauthorization)
+
+        # check that the file is in place
+        try:
+            wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
+            assert (disable_check or _do_request(wellknown_url)[0] == keyauthorization)
+        except (AssertionError, ValueError) as e:
+            raise ValueError("Wrote file, but couldn't download {0}: {1}".format(wellknown_url, e))
 
         # say the challenge is done
         _send_signed_request(challenge['url'], {}, "Error submitting challenges: {0}".format(domain))
@@ -149,6 +156,6 @@ def get_crt(account_key, csr, set_acme, contact=None):
         raise ValueError("Order failed: {0}".format(order))
 
     # download the certificate
-    certificate_pem, _, _ = _do_request(order['certificate'], err_msg="Certificate download failed")
+    certificate_pem, _, _ = _send_signed_request(order['certificate'], None, "Certificate download failed")
     logger.info("Certificate signed!")
     return certificate_pem

--- a/pritunl/acme_tiny.py
+++ b/pritunl/acme_tiny.py
@@ -38,7 +38,7 @@ def get_crt(account_key, csr, set_acme, contact=None, disable_check=False):
             resp_data = json.loads(resp_data) # try to parse json results
         except ValueError:
             pass # ignore json parsing errors
-        if depth < 100 and code == 400 and json.loads(resp_data)['type'] == "urn:ietf:params:acme:error:badNonce":
+        if depth < 100 and code == 400 and resp_data['type'] == "urn:ietf:params:acme:error:badNonce":
             raise IndexError(resp_data) # allow 100 retrys for bad nonces
         if code not in [200, 201, 204]:
             raise ValueError("{0}:\nUrl: {1}\nData: {2}\nResponse Code: {3}\nResponse: {4}".format(err_msg, url, data, code, resp_data))


### PR DESCRIPTION
The original error:
```
Traceback (most recent call last):
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/task.py", line 82, in run
    self.task()
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/tasks/acme_update.py", line 42, in task
    acme.update_acme_cert()
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/acme.py", line 68, in update_acme_cert
    cert = get_acme_cert(settings.app.acme_key, csr)
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/acme.py", line 43, in get_acme_cert
    set_acme,
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/acme_tiny.py", line 124, in get_crt
    authorization, _, _ = _do_request(auth_url, err_msg="Error getting challenges")
  File "/usr/lib/pritunl/lib/python2.7/site-packages/pritunl/acme_tiny.py", line 44, in _do_request
    raise ValueError("{0}:\nUrl: {1}\nData: {2}\nResponse Code: {3}\nResponse: {4}".format(err_msg, url, data, code, resp_data))
ValueError: Error getting challenges:
Url: https://acme-staging-v02.api.letsencrypt.org/acme/authz-v3/207466881
Data: None
Response Code: 405
Response: {
  "type": "urn:ietf:params:acme:error:malformed",
  "detail": "Method not allowed",
  "status": 405
}
```
Comes from the fact that the GET method has been replaced by POST for several stages of the ACME process.

<img width="869" alt="Screen Shot 2021-02-12 at 1 02 14 AM" src="https://user-images.githubusercontent.com/852320/107748867-91327d00-6cce-11eb-9726-b8c2721a6371.png">

This PR enables use of the LetsEncrypt-Staging directory by making sure:
1. `_send_signed_request()` is now properly sending "" (empty-string) to force a POST when appropriate
2. `_do_request()` is now only used for the directory, then all other requests use `_send_signed_request()`