### PR TITLE
Pass google groups to plugin, don't override it if found

### DIFF
--- a/pritunl/handlers/sso.py
+++ b/pritunl/handlers/sso.py
@@ -666,9 +666,22 @@ def sso_callback_get():
             user_name=username,
             user_email=email,
             remote_ip=remote_addr,
+            sso_group_names=google_groups
         )
+        not_found = True
+
         if valid:
-            org_id = org_id_new or org_id
+            if org_id_new:
+                org_id = org_id_new
+                not_found = False
+            else:
+                logger.warning('Plugin returned invalid org name',
+                   'sso',
+                    sso_type=doc.get('type'),
+                    user_name=username,
+                    user_email=email,
+                    org_names=google_groups,
+                )
         else:
             logger.error('Google plugin authentication not valid', 'sso',
                 username=username,
@@ -687,8 +700,7 @@ def sso_callback_get():
 
         if settings.app.sso_google_mode == 'groups':
             groups = groups | set(google_groups)
-        else:
-            not_found = False
+        elif not_found:
             google_groups = sorted(google_groups)
             for org_name in google_groups:
                 org = organization.get_by_name(


### PR DESCRIPTION
This fixes two issues with the google plugin mechanisms (Possibly same issue with other SSO) - 

1. Google groups were not being passed to the plugin
2. When the user had groups that were valid organizations in Pritunl, the code overwrote the organization return by the plugin.