### PR TITLE
Allow Certificate SAN & fix ACME DuplicateKeyError

### DIFF
--- a/pritunl/handlers/settings.py
+++ b/pritunl/handlers/settings.py
@@ -339,7 +339,8 @@ def settings_put():
         settings_commit = True
 
         acme_domain = utils.filter_str(
-            flask.request.json['acme_domain'] or None)
+            flask.request.json['acme_domain'] or None,
+            allow=",") # wildcards not allowed because they are not http-01
         if acme_domain:
             acme_domain = acme_domain.replace('https://', '')
             acme_domain = acme_domain.replace('http://', '')

--- a/pritunl/utils/misc.py
+++ b/pritunl/utils/misc.py
@@ -282,12 +282,15 @@ def rmtree(path):
                 )
             time.sleep(0.01)
 
-def filter_str(in_str):
+def filter_str(in_str, allow=""):
+    include = set()
+    if isinstance(allow, str):
+        include = {x for x in allow}
     if in_str is not None:
         in_str = str(in_str)
     if not in_str:
         return in_str
-    return ''.join(x for x in in_str if x.isalnum() or x in NAME_SAFE_CHARS)
+    return ''.join(x for x in in_str if x.isalnum() or x in NAME_SAFE_CHARS|include)
 
 def filter_str_uni(in_str):
     if in_str is not None:


### PR DESCRIPTION
- updated to accept SAN by allowing comma-delimited domains in the LetsEncrypt field
- CSR was changed to be generated via config file, allowing for the use of SAN
- Mongo insert of ACME token now ignores DuplicateKeyError