### PR TITLE
Fix logging of duo errors

### DIFF
--- a/pritunl/sso/duo.py
+++ b/pritunl/sso/duo.py
@@ -121,7 +121,7 @@ class Duo(object):
                 logger.error('Invalid Duo username',
                     'sso',
                     username=self.username,
-                    data=resp_data,
+                    data=data,
                 )
                 raise InvalidUser('Invalid username')
         else:


### PR DESCRIPTION
There would be no resp_data in case of a failure. So this should log the entire data (more here https://help.duo.com/s/article/1338?language=en_US )