### PR TITLE
Update radius.py

### DIFF
--- a/pritunl/sso/radius.py
+++ b/pritunl/sso/radius.py
@@ -32,7 +32,7 @@ def verify_radius(username, password):
         req = conn.CreateAuthPacket(
             code=packet.AccessRequest,
             User_Name=(
-                settings.app.sso_radius_prefix or '') + username.encode(),
+                settings.app.sso_radius_prefix or '') + str(username),
         )
         req['User-Password'] = req.PwCrypt(password)
 


### PR DESCRIPTION
When authenticating against a radius server we get the below error. I assume username is a string and .encode is returning bytes. I've removed the encoding and force it to str.

<img width="1252" alt="image" src="https://user-images.githubusercontent.com/5644316/122615598-02e85200-d046-11eb-97ac-143d6a876b68.png">

