### PR TITLE
fix check_session crash bug

### DIFF
--- a/pritunl/auth/administrator.py
+++ b/pritunl/auth/administrator.py
@@ -425,7 +425,7 @@ def check_session(csrf_check):
 
         auth_test_signature = base64.b64encode(hmac.new(
             administrator.secret.encode(), auth_string.encode(),
-            hashlib.sha256).digest())
+            hashlib.sha256).digest()).decode()
         if not utils.const_compare(auth_signature, auth_test_signature):
             return False
 


### PR DESCRIPTION
There is a problem of `check_session` function.

When `auth_token` is not none, it will call `utils.const_compare` fucntion to compare `auth_signature` and `auth_test_signature`. The `utils.const_compare` require two str type params. But `auth_test_signature` is a bytes. It will be crash.

![image](https://user-images.githubusercontent.com/6534748/122908115-5e884780-d386-11eb-801b-162940ab58d4.png)

So, before call `utils.const_compare`, `auth_test_signature` should be decode.