### PR TITLE
Fixed typo in "auditing" constants

### DIFF
--- a/pritunl/constants.py
+++ b/pritunl/constants.py
@@ -912,8 +912,8 @@ REQUIRES_SUPER_USER = 'requires_super_user'
 REQUIRES_SUPER_USER_MSG = 'This administrator action can only be ' + \
     'performed by a super user.'
 
-CANNOT_DISABLE_AUTIDING = 'cannot_disable_autiding'
-CANNOT_DISABLE_AUTIDING_MSG = 'Auditing cannot be disabled from web console.'
+CANNOT_DISABLE_AUDITING = 'cannot_disable_auditing'
+CANNOT_DISABLE_AUDITING_MSG = 'Auditing cannot be disabled from web console.'
 
 RANDOM_ONE = (
     'snowy',

--- a/pritunl/handlers/settings.py
+++ b/pritunl/handlers/settings.py
@@ -371,8 +371,8 @@ def settings_put():
 
         if settings.app.auditing == ALL and auditing != ALL:
             return utils.jsonify({
-                'error': CANNOT_DISABLE_AUTIDING,
-                'error_msg': CANNOT_DISABLE_AUTIDING_MSG,
+                'error': CANNOT_DISABLE_AUDITING,
+                'error_msg': CANNOT_DISABLE_AUDITING_MSG,
             }, 400)
 
         if settings.app.auditing != auditing:


### PR DESCRIPTION
Hey there! I've accidentally found this typo when working on `settings_override` resource for [Pritunl Terraform provider](https://github.com/disc/terraform-provider-pritunl).