### PR TITLE
Update requirements.txt, pin itsdangerous==2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ cryptography==3.4.7
 pynacl==1.5.0
 certifi==2021.10.8
 cffi==1.15.0
+itsdangerous==2.0.1


### PR DESCRIPTION
Just built 1.30.3101.81 from source and seeing a constant crash & restart:
```
Traceback (most recent call last):
  File "/usr/bin/pritunl", line 33, in <module>
    sys.exit(load_entry_point('pritunl==1.30.3101.81', 'console_scripts', 'pritunl')())
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/__main__.py", line 235, in main
    from pritunl import setup
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/setup/__init__.py", line 2, in <module>
    from pritunl.setup.clean import setup_clean
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/setup/clean.py", line 1, in <module>
    from pritunl import utils
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/utils/__init__.py", line 1, in <module>
    from pritunl.utils.cert import *
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/utils/cert.py", line 2, in <module>
    from pritunl.utils.misc import check_output_logged, get_temp_path
  File "/usr/lib/python3.9/site-packages/pritunl-1.30.3101.81-py3.9.egg/pritunl/utils/misc.py", line 15, in <module>
    import flask
  File "/usr/lib/python3.9/site-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/usr/lib/python3.9/site-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/usr/lib/python3.9/site-packages/itsdangerous/__init__.py)
```
at startup.

Looks like flask needs to be upgraded, or itsdangerous should be pinned to 2.0.1 in the pritunl requirements.txt
https://github.com/pallets/itsdangerous/issues/290
https://itsdangerous.palletsprojects.com/en/2.1.x/changes/

Temporary fix for me is to manually pre-install itsdangerous 2.0.1 before building pritunl from source so the latest version isn't pulled in by flask requirements:
```pip3 install itsdangerous==2.0.1
---
Requirement already satisfied: itsdangerous>=0.24 in /usr/lib/python3.9/site-packages (from flask==1.1.2->-r requirements.txt (line 1)) (2.0.1)
```