### PR TITLE
Fixed invalid ChromeOS profile generation

### DIFF
--- a/pritunl/user/user.py
+++ b/pritunl/user/user.py
@@ -1114,7 +1114,7 @@ class User(mongo.MongoObject):
             for cert_id, cert in list(onc_certs_store.items()):
                 onc_certs += OVPN_ONC_CA_CERT % (cert_id, cert) + ',\n'
             onc_certs += OVPN_ONC_CLIENT_CERT % (
-                user_cert_id, user_key_base64)
+                user_cert_id, user_key_base64.decode())
 
             onc_conf = OVPN_ONC_CLIENT_CONF % (onc_nets, onc_certs)
         finally:


### PR DESCRIPTION
When trying to import an .onc (ChromeOS profile) file, the profile imports successfully but ChromeOS complains that one of the user certificates is invalid. Upon closer investigation, it appears that the base64 representation was substituted incorrectly into the template, presumably missed out when Pritunl introduced Python 3 compatibility.

This commit runs .decode() on the return value of b64encode so as to ensure a string gets substituted instead of bytes.