### PR TITLE
Decode redis response as string instead of bytes

### DIFF
--- a/pritunl/cache.py
+++ b/pritunl/cache.py
@@ -28,6 +28,7 @@ def init():
 
     _client = redis.StrictRedis.from_url(
         redis_uri,
+        decode_responses=True,
         socket_timeout=settings.app.redis_timeout,
         socket_connect_timeout=settings.app.redis_timeout,
     )


### PR DESCRIPTION
Option ```pritunl app.redis_uri redis://localhost/0``` not work as expected.
The point is that redis cache sends response in bytes.
And such respone does not match in ```runners/listener.py:23```

```
msg['channel'] == b"servers" # but expected "servers"
```

runners/listener.py:
```
....
            for msg in messenger.subscribe(list(listener.channels.keys())):
                for lstnr in listener.channels[msg['channel']]: # <==== this line
                    try:
                        queue.put(lstnr, msg)

                        size = queue.size()

....
```
