### PR TITLE
Change journal timestamp type

### DIFF
--- a/pritunl/journal/__init__.py
+++ b/pritunl/journal/__init__.py
@@ -13,7 +13,7 @@ def get_base_entry(event):
     data = {
         'id': bson.ObjectId(),
         'event': event,
-        'timestamp': utils.time_now(),
+        'timestamp': int(utils.time_now() * 1000),
     }
 
     data.update(settings.local.host.journal_data)


### PR DESCRIPTION
Hey Pritunl team,

I'm running Pritunl in a Docker container, following the official docs for [installation](https://docs.pritunl.com/docs/installation), [backup](https://docs.pritunl.com/docs/backup), and [WireGuard](https://docs.pritunl.com/docs/wireguard)—huge thanks for the great documentation!

I’ve successfully sent logs from `/var/log/pritunl.log` to my monitoring platform without any issues. However, when trying to send journal logs in `/var/log/pritunl_journal.log`, I ran into a problem—the timestamps are in UNIX time as a float.

Some monitoring platforms like [Datadog](https://docs.datadoghq.com/service_management/events/pipelines_and_processors/date_remapper/), [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html), and [Dynatrace](https://docs.dynatrace.com/docs/analyze-explore-automate/log-monitoring/log-monitoring-configuration/timestamp-data-format) does not accept this format by default. Yes, I can transform logs during ingestion, but this requires custom configurations. I believe a better approach would be to standardize timestamps to UNIX time as an integer, eliminating the need for extra preprocessing or customization.

I made a small update and would love to hear your thoughts on this change!