### PR TITLE
Add request timeouts to SSO and vault HTTP calls

### DIFF
--- a/pritunl/sso/jumpcloud.py
+++ b/pritunl/sso/jumpcloud.py
@@ -17,6 +17,7 @@ def auth_jumpcloud(username):
                 'Accept': 'application/json',
                 'X-Api-Key': settings.app.sso_jumpcloud_secret,
             },
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('JumpCloud api error', 'sso',
@@ -72,6 +73,7 @@ def auth_jumpcloud(username):
                 'Accept': 'application/json',
                 'X-Api-Key': settings.app.sso_jumpcloud_secret,
             },
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('JumpCloud api error', 'sso',

--- a/pritunl/sso/okta.py
+++ b/pritunl/sso/okta.py
@@ -21,6 +21,7 @@ def get_user_id(username):
                 'User-Agent': USER_AGENT,
                 'Authorization': 'SSWS %s' % settings.app.sso_okta_token,
             },
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('Okta api error', 'sso',
@@ -73,6 +74,7 @@ def auth_okta(username):
                 'User-Agent': USER_AGENT,
                 'Authorization': 'SSWS %s' % settings.app.sso_okta_token,
             },
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('Okta api error', 'sso',
@@ -147,6 +149,7 @@ def auth_okta_secondary(username, passcode, remote_ip, okta_mode, platform):
                 'User-Agent': USER_AGENT,
                 'Authorization': 'SSWS %s' % settings.app.sso_okta_token,
             },
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('Okta api error', 'sso',
@@ -230,6 +233,7 @@ def auth_okta_secondary(username, passcode, remote_ip, okta_mode, platform):
                 'X-Forwarded-For': remote_ip,
             },
             json=verify_data,
+            timeout=30,
         )
     except http.client.HTTPException:
         logger.exception('Okta api error', 'sso',
@@ -310,6 +314,7 @@ def auth_okta_secondary(username, passcode, remote_ip, okta_mode, platform):
                     'User-Agent': useragent,
                     'Authorization': 'SSWS %s' % settings.app.sso_okta_token,
                 },
+                timeout=30,
             )
         except http.client.HTTPException:
             logger.exception('Okta poll api error', 'sso',

--- a/pritunl/sso/onelogin.py
+++ b/pritunl/sso/onelogin.py
@@ -25,6 +25,7 @@ def _get_access_token():
         json={
             'grant_type': 'client_credentials',
         },
+        timeout=30,
     )
 
     if response.status_code != 200:
@@ -44,6 +45,7 @@ def auth_onelogin(username):
                 ONELOGIN_URL + '/api/v3/users/username/%s' % (
                     urllib.parse.quote(username)),
                 auth=(settings.app.sso_onelogin_key, 'x'),
+                timeout=30,
                 )
         except http.client.HTTPException:
             logger.exception('OneLogin api error', 'sso',
@@ -88,6 +90,7 @@ def auth_onelogin(username):
         params={
             'username': username,
         },
+        timeout=30,
     )
 
     if response.status_code != 200:
@@ -128,6 +131,7 @@ def auth_onelogin(username):
         headers={
             'Authorization': 'bearer:%s' % access_token,
         },
+        timeout=30,
     )
 
     if response.status_code != 200:
@@ -175,6 +179,7 @@ def auth_onelogin_secondary(username, passcode, remote_ip, onelogin_mode):
         params={
             'username': username,
         },
+        timeout=30,
     )
 
     if response.status_code != 200:
@@ -206,6 +211,7 @@ def auth_onelogin_secondary(username, passcode, remote_ip, onelogin_mode):
         headers={
             'Authorization': 'bearer:%s' % access_token,
         },
+        timeout=30,
     )
 
     if response.status_code != 200:
@@ -260,6 +266,7 @@ def auth_onelogin_secondary(username, passcode, remote_ip, onelogin_mode):
             json={
                 'ipaddr': remote_ip,
             },
+            timeout=30,
         )
 
         if response.status_code != 200:
@@ -303,6 +310,7 @@ def auth_onelogin_secondary(username, passcode, remote_ip, onelogin_mode):
                 'state_token': state_token,
                 'otp_token': passcode,
             },
+            timeout=30,
         )
 
         if response.status_code != 200 and response.status_code != 401:

--- a/pritunl/vault/batch.py
+++ b/pritunl/vault/batch.py
@@ -68,6 +68,7 @@ class Batch(object):
                 'Content-Type': 'application/json',
             },
             data=json.dumps(payload),
+            timeout=10,
         )
 
         if resp.status_code != 200:

--- a/pritunl/vault/vault.py
+++ b/pritunl/vault/vault.py
@@ -24,6 +24,7 @@ def init():
         headers={
             'User-Agent': 'pritunl',
         },
+        timeout=10,
     )
 
     if resp.status_code != 200:
@@ -93,6 +94,7 @@ def init_host_key():
             'Content-Type': 'application/json',
         },
         data=json.dumps(payload),
+        timeout=10,
     )
 
     if resp.status_code != 200:
@@ -109,6 +111,7 @@ def init_server_key():
             'User-Agent': 'pritunl',
             'Accept': 'application/json',
         },
+        timeout=10,
     )
 
     if resp.status_code != 200:
@@ -238,6 +241,7 @@ def init_master_key(cipher_data):
             'Content-Type': 'application/json',
         },
         data=json.dumps(payload),
+        timeout=10,
     )
 
     if resp.status_code != 200:


### PR DESCRIPTION
The HTTP calls in the SSO integrations (Okta, OneLogin, JumpCloud) and the vault layer have no timeout set, which means a slow or unresponsive upstream can stall a worker thread indefinitely.

Added `timeout=30` on the external SSO API calls and `timeout=10` on the vault loopback calls (127.0.0.1:9758), since those should respond quickly.

Files changed:
- `pritunl/sso/okta.py`
- `pritunl/sso/onelogin.py`
- `pritunl/sso/jumpcloud.py`
- `pritunl/vault/vault.py`
- `pritunl/vault/batch.py`