### PR TITLE
Fix SMTP STARTTLS: split host:port for correct SNI

### DIFF
--- a/pritunl/utils/mail.py
+++ b/pritunl/utils/mail.py
@@ -26,26 +26,33 @@ def send_email(to_addr, subject, text_body, html_body):
     msg.attach(email.mime.text.MIMEText(html_body, 'html'))
 
     try:
+        if ':' in email_server:
+            email_host, email_port = email_server.rsplit(':', 1)
+            email_port = int(email_port)
+        else:
+            email_host = email_server
+            email_port = 0
+
         context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         if settings.app.email_skip_verify:
             context.check_hostname = False
             context.verify_mode = ssl.CERT_NONE
         context.minimum_version = ssl.TLSVersion.TLSv1_2
         if not email_username and not email_password:
-            smtp_conn = smtplib.SMTP(email_server)
+            smtp_conn = smtplib.SMTP(email_host, email_port)
             if settings.app.email_tls:
                 smtp_conn.ehlo()
                 smtp_conn.starttls(context=context)
                 smtp_conn.ehlo()
         else:
             if settings.app.email_tls:
-                smtp_conn = smtplib.SMTP(email_server)
+                smtp_conn = smtplib.SMTP(email_host, email_port)
                 smtp_conn.ehlo()
                 smtp_conn.starttls(context=context)
                 smtp_conn.ehlo()
                 smtp_conn.login(email_username, email_password)
             else:
-                smtp_conn = smtplib.SMTP_SSL(email_server)
+                smtp_conn = smtplib.SMTP_SSL(email_host, email_port)
                 smtp_conn.login(email_username, email_password)
 
         smtp_conn.sendmail(email_from, to_addr, msg.as_string())


### PR DESCRIPTION
## Summary

Fixes a bug in `pritunl/utils/mail.py` `send_email()` that breaks STARTTLS against strict SMTP relays (e.g. AWS SES).

### Bug — Malformed SNI causes STARTTLS failure against AWS SES (and other strict relays)

`email_server` has the form `"host:port"` and is passed as a single argument to `smtplib.SMTP()`. `smtplib` parses the port for the TCP connection but stores the original string as `self._host`, which is then used as the SNI hostname during `starttls()`. The resulting SNI extension contains a port suffix, which violates RFC 6066. Strict relays such as AWS SES reject the handshake:

```
ssl.SSLError: [SSL: SSLV3_ALERT_ILLEGAL_PARAMETER] sslv3 alert illegal parameter (_ssl.c:1147)
```

Reproduction with the bundled Python:

```python
import smtplib, ssl
ctx = ssl.create_default_context()

# Fails:
s = smtplib.SMTP("email-smtp.eu-west-1.amazonaws.com:587", timeout=10)
s.ehlo(); s.starttls(context=ctx)

# Succeeds:
s = smtplib.SMTP("email-smtp.eu-west-1.amazonaws.com", 587, timeout=10)
s.ehlo(); s.starttls(context=ctx)
```

A raw `openssl s_client -starttls smtp -connect email-smtp.eu-west-1.amazonaws.com:587` from the same host succeeds, confirming this is not a network or relay issue.

This was introduced in 29e83eb (July 2019, "Add tls to send email"), which added STARTTLS without splitting `host:port`. The same string is also passed to the `SMTP_SSL` branch; implicit TLS is more lenient about SNI, but splitting host/port there too keeps the three call sites consistent.

## Fix

Split `email_server` into `email_host` / `email_port` once before the SMTP branches and pass them as separate arguments to `smtplib.SMTP()` and `smtplib.SMTP_SSL()`. The existing TLS context configuration (`PROTOCOL_TLS_CLIENT`, `email_skip_verify`, `TLSv1_2` minimum) is left untouched.

## Verification

Tested on Pritunl 1.32.4567.52 against AWS SES `email-smtp.eu-west-1.amazonaws.com:587` with STARTTLS. Email sends successfully and the relay's certificate is properly verified.

---

*Note: this PR was prepared with the help of an AI assistant; the bug, reproduction, and fix were verified on a real Pritunl deployment before submission.*