### PR TITLE
Add sso_webauth: per-connection SSO for third-party OpenVPN clients

### DIFF
--- a/pritunl/clients/clients.py
+++ b/pritunl/clients/clients.py
@@ -1364,6 +1364,9 @@ class Clients(object):
             _, password = password.split('<%=AUTH_TOKEN=%>')
             password = password or None
 
+        if client_data.get('injected_sso_token'):
+            sso_token = client_data['injected_sso_token']
+
         try:
             if not _limiter.validate(remote_ip):
                 self.instance_com.send_client_deny(client_id, key_id,
@@ -1385,6 +1388,13 @@ class Clients(object):
             if not user:
                 self.instance_com.send_client_deny(client_id, key_id,
                     'User is not valid')
+                return
+
+            if not reauth and self.server.sso_auth and \
+                    self.server.sso_webauth and not user.link_server_id and \
+                    not has_token and not sso_token and \
+                    'webauth' in (client_data.get('iv_sso') or ''):
+                self.sso_webauth_request(client_data, org, user)
                 return
 
             def callback(allow, reason=None, doc_id=None):
@@ -1474,6 +1484,84 @@ class Clients(object):
 
     def connect(self, client_data, reauth=False):
         self.call_queue.put(self._connect, client_data, reauth)
+
+    def sso_webauth_request(self, client_data, org, user):
+        from pritunl import sso
+
+        client_id = client_data['client_id']
+        key_id = client_data['key_id']
+        timeout = settings.vpn.sso_webauth_timeout
+
+        state = utils.rand_str(64)
+        token = utils.rand_str(32)
+
+        mongo.get_collection('key_tokens').insert_one({
+            '_id': state,
+            'org_id': org.id,
+            'user_id': user.id,
+            'server_id': self.server.id,
+            'mode': 'ovpn',
+            'token': token,
+            'type': KEY_REQUEST_AUTH,
+            'secret': None,
+            'timestamp': utils.now(),
+        })
+
+        url = sso.server_sso_url() + '/key/request?state=' + state
+        extra = 'WEB_AUTH::' + url
+
+        logger.info('Sending sso web auth pending challenge', 'clients',
+            user_name=user.name,
+            org_name=org.name,
+            server_name=self.server.name,
+        )
+
+        thread = threading.Thread(
+            name="SsoWebauthPoll",
+            target=self.sso_webauth_poll,
+            args=(client_data, token),
+        )
+        thread.daemon = True
+        thread.start()
+
+        self.instance_com.send_client_pending_auth(client_id, key_id,
+            extra, timeout)
+
+    def sso_webauth_poll(self, client_data, token):
+        from pritunl import sso
+
+        client_id = client_data['client_id']
+        key_id = client_data['key_id']
+        timeout = settings.vpn.sso_webauth_timeout
+
+        for _ in range(timeout * 5):
+            time.sleep(0.2)
+
+            if self.instance.sock_interrupt:
+                return
+
+            if sso.check_token(token, client_data['user_id'], self.server.id):
+                self.sso_webauth_approve(client_data)
+                return
+
+        try:
+            self.instance_com.send_client_deny(client_id, key_id,
+                'Web authentication timed out')
+        except:
+            pass
+
+    def sso_webauth_approve(self, client_data):
+        sso_token = utils.rand_str(32)
+        mongo.get_collection('server_sso_tokens').insert_one({
+            '_id': sso_token,
+            'user_id': client_data['user_id'],
+            'server_id': self.server.id,
+            'stage': 'connect',
+            'timestamp': utils.now(),
+        })
+
+        client_data['injected_sso_token'] = sso_token
+        self.call_queue.put(self._connect, client_data, False)
 
     def connect_wg(self, user, org, wg_public_key, auth_password,
             auth_token, auth_nonce, auth_timestamp, sso_token,

--- a/pritunl/server/instance.py
+++ b/pritunl/server/instance.py
@@ -1779,6 +1779,7 @@ class ServerInstance(object):
             geo_sort=self.server.geo_sort,
             force_connect=self.server.force_connect,
             sso_auth=self.server.sso_auth,
+            sso_webauth=self.server.sso_webauth,
             route_dns=self.server.route_dns,
             device_auth=self.server.device_auth,
             host_id=settings.local.host.id,

--- a/pritunl/server/instance_com.py
+++ b/pritunl/server/instance_com.py
@@ -20,6 +20,24 @@ import uuid
 import random
 import bson
 import ipaddress
+import subprocess
+
+_pending_auth_kid = None
+
+def pending_auth_supports_kid():
+    global _pending_auth_kid
+    if _pending_auth_kid is None:
+        supported = False
+        try:
+            proc = subprocess.Popen(['openvpn', '--version'],
+                stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            ver = proc.communicate()[0].decode().split()[1]
+            major, minor = ver.split('.')[:2]
+            supported = (int(major), int(minor)) >= (2, 6)
+        except:
+            supported = False
+        _pending_auth_kid = supported
+    return _pending_auth_kid
 
 class ServerInstanceCom(object):
     def __init__(self, svr, instance):
@@ -62,6 +80,14 @@ class ServerInstanceCom(object):
         self.sock_send('client-deny %s %s "%s"%s\n' % (client_id, key_id,
             reason, ((' "%s"' % client_reason) if client_reason else '')))
         self.push_output('ERROR User auth failed "%s"' % reason)
+
+    def send_client_pending_auth(self, client_id, key_id, extra, timeout):
+        if pending_auth_supports_kid():
+            self.sock_send('client-pending-auth %s %s "%s" %s\n' % (
+                client_id, key_id, extra, timeout))
+        else:
+            self.sock_send('client-pending-auth %s "%s" %s\n' % (
+                client_id, extra, timeout))
 
     def push_output(self, message):
         self.server.output.push_message(message)
@@ -139,6 +165,8 @@ class ServerInstanceCom(object):
                     self.client['platform'] = utils.filter_str(env_val)
                 elif env_key == 'IV_VER':
                     self.client['ovpn_ver'] = utils.filter_str(env_val)
+                elif env_key == 'IV_SSO':
+                    self.client['iv_sso'] = utils.filter_str(env_val)
                 elif env_key == 'UV_ID':
                     self.client['device_id'] = utils.filter_str(env_val)
                 elif env_key == 'UV_NAME':

--- a/pritunl/server/server.py
+++ b/pritunl/server/server.py
@@ -68,6 +68,7 @@ dict_fields = [
     'search_domain',
     'otp_auth',
     'sso_auth',
+    'sso_webauth',
     'cipher',
     'hash',
     'block_outside_dns',
@@ -140,6 +141,7 @@ class Server(mongo.MongoObject):
         'search_domain',
         'otp_auth',
         'sso_auth',
+        'sso_webauth',
         'tls_auth',
         'tls_auth_key',
         'lzo_compression',
@@ -206,6 +208,7 @@ class Server(mongo.MongoObject):
         'dns_servers': [],
         'otp_auth': False,
         'sso_auth': False,
+        'sso_webauth': False,
         'tls_auth': True,
         'lzo_compression': False,
         'hide_ovpn': False,
@@ -248,7 +251,8 @@ class Server(mongo.MongoObject):
             restrict_routes=None, wg=None, ipv6=None, ipv6_firewall=None,
             bind_address=None, port=None, protocol=None, port_wg=None,
             dh_param_bits=None, multi_device=None, dns_servers=None,
-            search_domain=None, otp_auth=None, sso_auth=None, cipher=None,
+            search_domain=None, otp_auth=None, sso_auth=None,
+            sso_webauth=None, cipher=None,
             hash=None, block_outside_dns=None, jumbo_frames=None,
             lzo_compression=None, inter_client=None, ping_interval=None,
             ping_timeout=None, ping_interval_wg=None, ping_timeout_wg=None,
@@ -326,6 +330,8 @@ class Server(mongo.MongoObject):
             self.otp_auth = otp_auth
         if sso_auth is not None:
             self.sso_auth = sso_auth
+        if sso_webauth is not None:
+            self.sso_webauth = sso_webauth
         if cipher is not None:
             self.cipher = cipher
         if hash is not None:
@@ -457,6 +463,7 @@ class Server(mongo.MongoObject):
             'search_domain': self.search_domain,
             'otp_auth': True if self.otp_auth else False,
             'sso_auth': True if self.sso_auth else False,
+            'sso_webauth': True if self.sso_webauth else False,
             'cipher': self.cipher,
             'hash': self.hash,
             'block_outside_dns': self.block_outside_dns,

--- a/pritunl/settings/vpn.py
+++ b/pritunl/settings/vpn.py
@@ -30,6 +30,7 @@ class SettingsVpn(SettingsGroupMongo):
         'link_timeout': 10,
         'firewall_connect_timeout': 180,
         'sso_token_ttl': 300,
+        'sso_webauth_timeout': 180,
         'drop_permissions': False,
         'bandwidth_update_rate': 15,
         'tls_mode': 'tls-auth',


### PR DESCRIPTION
Adds an opt-in `sso_webauth` server option so stock OpenVPN clients (OpenVPN Connect, ics-openvpn) can complete per-connection SSO via OpenVPN's standard WEB_AUTH / AUTH_PENDING protocol. Previously only the official desktop client could, so mobile/third-party clients got `AUTH_FAILED`.

When enabled alongside `sso_auth`, a tokenless client advertising `IV_SSO=webauth` is sent `client-pending-auth "WEB_AUTH::<root>/key/request?state=..."`, authenticates through Pritunl's existing `/key/request -> /key/callback -> /success` flow, and the held connection is approved via the existing `server_sso_tokens` mechanism — the same machinery the desktop client uses.

Opt-in (default off). Desktop-client, profile-download, and non-SSO flows are unchanged; no changes to `handlers/sso.py` or `handlers/key.py`. Requires an OpenVPN 2.6+ server (already shipped).

Tested on 1.34 with Google Workspace SSO: OpenVPN Connect -> browser login -> `/success` -> connected.